### PR TITLE
add promotion to semaphoreci 

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,9 +8,6 @@ agent:
 blocks:
   - name: "Tests"
     task:
-#      secrets:
-#        - name: TERRAFORM_GITHUB_CREDENTIALS
-#        - name: TERRAFORM_AWS_TESTACCOUNT_CREDENTIALS
       prologue:
         commands:
           - checkout --use-cache
@@ -19,7 +16,8 @@ blocks:
           commands:
             - make docker/pre-commit-hooks
 
-# There are no unit tests inside this repository since it acts as a code convention example only
-#        - name: "Unit Tests"
-#          commands:
-#            - make docker/unit-tests
+promotions:
+  - name: "Unit Tests"
+    pipeline_file: unit-tests.yml
+    auto_promote:
+      when: "branch = 'master'"

--- a/.semaphore/unit-tests.yml
+++ b/.semaphore/unit-tests.yml
@@ -1,0 +1,18 @@
+version: v1.0
+name: "Promotions and Auto-promotions"
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: "Unit Tests"
+    task:
+      secrets:
+        - name: TERRAFORM_AWS_TESTACCOUNT_CREDENTIALS
+      prologue:
+        commands:
+          - checkout --use-cache
+      jobs:
+        - name: "Run Go Tests"
+          commands:
+            - make docker/unit-tests


### PR DESCRIPTION
adds a promotion to [SemaphoreCI](https://mineiros.semaphoreci.com/workflows/7351c339-a709-4d0f-965a-1c5e729a1aa5) configuration to execute the unit tests manually or when a check-in to master occurs.

