### PR TITLE
split up long txt records

### DIFF
--- a/examples/complete-example/main.tf
+++ b/examples/complete-example/main.tf
@@ -23,7 +23,7 @@ module "route53" {
   }
 
   google_mail_dkim = {
-    "google._domainkey" = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCg\"\"KCAQEAoeaZAFNfAvwiMkuIHimJVODdtPX+9d7uVhFrML2S8m0GNd0c9w8Os5nQBeQaBmm1h7S/yxYrc\"\"5lcV5eaF1TgBmg9fYrwKXG8u1+gotmhFHhWl/GebYiUa/PchLAG+rrSav7lDlB3uTcbMGZUPQ3uuQOEwqi7SRsAFilA\"\"YFIkK+N6Crpis9LABFVAkrWsEbxOpVArxAdRpe6UuYAnS/Ge1uGOKu3L1kK5AG\"\"VN2HIkQPEllAQ0KY2yiPGfQXw8SA5ibZ0FjKlnw4amocZyBSLBlpHo9/qzLAy9Jo\"\"ByTOoZXdijikPY7zioSGIfOaY0RqSIpR338VXhHS76QMrDG5fLwQIDAQAB"
+    "google._domainkey" = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoeaZAFNfAvwiMkuIHimJVODdtPX+9d7uVhFrML2S8m0GNd0c9w8Os5nQBeQaBmm1h7S/yxYrc5lcV5eaF1TgBmg9fYrwKXG8u1+gotmhFHhWl/GebYiUa/PchLAG+rrSav7lDlB3uTcbMGZUPQ3uuQOEwqi7SRsAFilAYFIkK+N6Crpis9LABFVAkrWsEbxOpVArxAdRpe6UuYAnS/Ge1uGOKu3L1kK5AGVN2HIkQPEllAQ0KY2yiPGfQXw8SA5ibZ0FjKlnw4amocZyBSLBlpHo9/qzLAy9JoByTOoZXdijikPY7zioSGIfOaY0RqSIpR338VXhHS76QMrDG5fLwQIDAQAB"
   }
 
   records = [

--- a/google-suite.tf
+++ b/google-suite.tf
@@ -51,5 +51,7 @@ resource "aws_route53_record" "google_dkim" {
   zone_id = aws_route53_zone.zone[var.name].id
   ttl     = 3600
 
-  records = [each.value]
+  records = [
+    length(regexall("(\\\"\\\")", each.value)) == 0 ? join("\"\"", compact(split("{SPLITHERE}", replace(each.value, "/(.{255})/", "$1{SPLITHERE}")))) : each.value
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -120,7 +120,7 @@ variable "records" {
   #
   # records = [
   #   {
-  #     name = "www.example.com"
+  #     name = "example.com"
   #     type = "A"
   #     ttl  = 300
   #     records = [
@@ -135,7 +135,17 @@ variable "records" {
   #     records = [
   #       "example.com"
   #     ]
-  #   }
+  #   },
+  #   {
+  #     name = "dev"
+  #     type = "CNAME"
+  #     alias = {
+  #        name                   = aws_elb.main.dns_name
+  #        zone_id                = aws_elb.main.zone_id
+  #        evaluate_target_health = true
+  #
+  #     }
+  #   },
   # ]
 
   default = []


### PR DESCRIPTION
txt records that have a length longer than 255 characters need to be split up due to a limitation in the DNS protocol.

- Separate Strings into substrings with `\"\"` if the string is longer than 255 characters
- Don't apply this rule if the string already contains a separator