### PR TITLE
Add configurable default ttl for records

### DIFF
--- a/examples/complete-example/main.tf
+++ b/examples/complete-example/main.tf
@@ -28,9 +28,10 @@ module "route53" {
 
   records = [
     {
+      # This record doesn't have ttl set explicitly, therefore it will assume the default ttl that is configurable
+      # through var.default_ttl
       type = "A"
       name = "testing.mineiros.io"
-      ttl  = 3600
       records = [
         "172.217.16.209"
       ]

--- a/google-suite.tf
+++ b/google-suite.tf
@@ -1,6 +1,6 @@
 # Create Google Mail MX entries
 resource "aws_route53_record" "google_mail_mx" {
-  count = var.create && var.create_google_mail_mx ? 1 : 0
+  count = var.enable_module && var.create_google_mail_mx ? 1 : 0
 
   name    = ""
   type    = "MX"
@@ -18,7 +18,7 @@ resource "aws_route53_record" "google_mail_mx" {
 
 # Create a range of CNAMES records for Google Suite Services
 resource "aws_route53_record" "google_suite_aliases" {
-  for_each = var.create ? var.google_suite_services_custom_aliases : {}
+  for_each = var.enable_module ? var.google_suite_services_custom_aliases : {}
 
   name    = each.value
   type    = "CNAME"
@@ -31,7 +31,7 @@ resource "aws_route53_record" "google_suite_aliases" {
 # Create a SPF record to prevent email spoofing
 # Notice that you need to verify the SPF record: https://support.google.com/a/answer/33786?hl=en
 resource "aws_route53_record" "google_spf" {
-  count = var.create && var.create_google_spf ? 1 : 0
+  count = var.enable_module && var.create_google_spf ? 1 : 0
 
   name    = ""
   type    = "SPF"
@@ -44,7 +44,7 @@ resource "aws_route53_record" "google_spf" {
 # Create the DKIM record to enhance security for outgoing email
 # Notice that you need to verify the DKIM record: https://support.google.com/a/answer/174126?hl=en
 resource "aws_route53_record" "google_dkim" {
-  for_each = var.create ? var.google_mail_dkim : {}
+  for_each = var.enable_module ? var.google_mail_dkim : {}
 
   name    = each.key
   type    = "TXT"

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   skip_zone_creation = length(local.zones) == 0
   zones              = var.name == null ? [] : try(tolist(var.name), [tostring(var.name)], [])
-  delegation_set_id  = var.delegation_set_id != "" ? var.delegation_set_id : try(aws_route53_delegation_set.delegation_set[0].id, null)
+  delegation_set_id  = var.delegation_set_id != null ? var.delegation_set_id : try(aws_route53_delegation_set.delegation_set[0].id, null)
 
   run_in_vpc = length(var.vpc_ids) > 0
 

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
 
   run_in_vpc = length(var.vpc_ids) > 0
 
-  skip_delegation_set_creation = ! var.create || local.skip_zone_creation || local.run_in_vpc ? true : var.skip_delegation_set_creation
+  skip_delegation_set_creation = ! var.enable_module || local.skip_zone_creation || local.run_in_vpc ? true : var.skip_delegation_set_creation
 }
 
 resource "aws_route53_delegation_set" "delegation_set" {
@@ -15,7 +15,7 @@ resource "aws_route53_delegation_set" "delegation_set" {
 }
 
 resource "aws_route53_zone" "zone" {
-  for_each = var.create ? toset(local.zones) : []
+  for_each = var.enable_module ? toset(local.zones) : []
 
   name              = each.value
   comment           = var.comment
@@ -50,7 +50,7 @@ locals {
     for record in local.records_expanded : record.record_id => record
   }
 
-  records_by_name = var.create ? {
+  records_by_name = var.enable_module ? {
     for product in setproduct(local.zones, keys(local.records_transposed)) :
     "${product[1]}-${product[0]}" => {
 
@@ -93,7 +93,7 @@ locals {
 }
 
 resource "aws_route53_record" "record" {
-  for_each = var.create ? local.records : {}
+  for_each = var.enable_module ? local.records : {}
 
   zone_id = each.value.zone_id
   type    = each.value.type

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ resource "aws_route53_zone" "zone" {
   for_each = var.create ? toset(local.zones) : []
 
   name              = each.value
+  comment           = var.comment
   force_destroy     = var.force_destroy
   delegation_set_id = local.delegation_set_id
 

--- a/variables.tf
+++ b/variables.tf
@@ -22,12 +22,6 @@ variable "name" {
 # These variables have defaults, but may be overridden.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "create" {
-  description = "Whether to create the Route53 Zone and it's associated resources."
-  type        = bool
-  default     = true
-}
-
 variable "comment" {
   description = "A comment for the hosted zone."
   type        = string
@@ -56,6 +50,12 @@ variable "delegation_set_id" {
   description = "The ID of the reusable delegation set whose NS records you want to assign to the hosted zone."
   type        = string
   default     = null
+}
+
+variable "enable_module" {
+  description = "Whether to enable the module and to create the Route53 Zone and it's associated resources."
+  type        = bool
+  default     = true
 }
 
 variable "force_destroy" {

--- a/variables.tf
+++ b/variables.tf
@@ -46,10 +46,10 @@ variable "create_google_spf" {
   default     = false
 }
 
-variable "skip_delegation_set_creation" {
-  description = "Whether or not to create a delegation set and associate with the created zone."
-  type        = bool
-  default     = false
+variable "default_ttl" {
+  description = "The default TTL ( Time to Live ) in seconds that will be used for all records that support the ttl parameter. Will be overwritten by the records ttl parameter if set."
+  type        = number
+  default     = 3600
 }
 
 variable "delegation_set_id" {
@@ -58,10 +58,10 @@ variable "delegation_set_id" {
   default     = ""
 }
 
-variable "reference_name" {
-  description = "The reference name used in Caller Reference (helpful for identifying single delegation set amongst others)."
-  type        = string
-  default     = ""
+variable "force_destroy" {
+  description = "Whether to force destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone."
+  type        = bool
+  default     = false
 }
 
 variable "google_mail_mx_ttl" {
@@ -81,12 +81,6 @@ variable "google_mail_dkim" {
   # }
 
   default = {}
-}
-
-variable "force_destroy" {
-  description = "Whether to force destroy all records (possibly managed outside of Terraform) in the zone when destroying the zone."
-  type        = bool
-  default     = false
 }
 
 variable "google_suite_services_custom_aliases" {
@@ -149,6 +143,18 @@ variable "records" {
   # ]
 
   default = []
+}
+
+variable "reference_name" {
+  description = "The reference name used in Caller Reference (helpful for identifying single delegation set amongst others)."
+  type        = string
+  default     = ""
+}
+
+variable "skip_delegation_set_creation" {
+  description = "Whether or not to create a delegation set and associate with the created zone."
+  type        = bool
+  default     = false
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "default_ttl" {
 variable "delegation_set_id" {
   description = "The ID of the reusable delegation set whose NS records you want to assign to the hosted zone."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "force_destroy" {


### PR DESCRIPTION
- add `default_ttl` variable to set default ttl in seconds for records
- implement `create` feature toggle. The variable existed previously but we failed to implement it.