### PR TITLE
Do not set a default reference-name (breaking change)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ locals {
 resource "aws_route53_delegation_set" "delegation_set" {
   count = local.skip_delegation_set_creation ? 0 : 1
 
-  reference_name = try(coalesce(var.reference_name, local.zones[0]), null)
+  reference_name = var.reference_name
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -131,7 +131,7 @@ variable "failover_records" {
 variable "reference_name" {
   description = "The reference name used in Caller Reference (helpful for identifying single delegation set amongst others)."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "skip_delegation_set_creation" {


### PR DESCRIPTION
how to unbreak: explicitly set reference_name

this breaks the idea of using resource for_each as it will recreate the delegation id if set by default to some value.. because: changing reference_name forces renew..